### PR TITLE
feat: allow toggling of PDF overlay

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/components/zoning/georeferencing.tsx
+++ b/src/components/zoning/georeferencing.tsx
@@ -9,14 +9,22 @@ import { MapPin, Eye, EyeOff } from "lucide-react";
 interface GeoreferencingProps {
   onGeoreference: (bounds: [number, number, number, number]) => void;
   disabled?: boolean;
+  overlayVisible: boolean;
+  onToggleOverlay: () => void;
+  overlayReady: boolean;
 }
 
-export const Georeferencing = ({ onGeoreference, disabled }: GeoreferencingProps) => {
+export const Georeferencing = ({
+  onGeoreference,
+  disabled,
+  overlayVisible,
+  onToggleOverlay,
+  overlayReady
+}: GeoreferencingProps) => {
   const [swLat, setSwLat] = useState("44.8200");
   const [swLng, setSwLng] = useState("-87.4000");
   const [neLat, setNeLat] = useState("44.8600");
   const [neLng, setNeLng] = useState("-87.3400");
-  const [overlayVisible, setOverlayVisible] = useState(true);
 
   const validateCoordinates = () => {
     const sw = [parseFloat(swLat), parseFloat(swLng)];
@@ -150,7 +158,8 @@ export const Georeferencing = ({ onGeoreference, disabled }: GeoreferencingProps
           <Button
             variant="outline"
             size="sm"
-            onClick={() => setOverlayVisible(!overlayVisible)}
+            onClick={onToggleOverlay}
+            disabled={!overlayReady}
             className="flex items-center gap-1"
           >
             {overlayVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -114,5 +115,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- allow users to toggle the PDF overlay during georeferencing
- refactor Tailwind config to use ES module imports
- fix lint warnings in command and textarea components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e5c8c1adc83298359b1371e3e1819